### PR TITLE
Bump dh-octave 1.5.0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,86 @@
-dh-octave (1.2.0) UNRELEASED; urgency=medium
+dh-octave (1.5.0) unstable; urgency=medium
 
-  * update
+  * Upload to unstable
 
- -- Debian Octave Group <team+pkg-octave-team@tracker.debian.org>  Thu, 16 Jun 2022 11:35:01 +0800
+  * dh_octave_make.in:
+    + Ensure a blank like before "Files: debian/*" stanza
+    + Get URL documentation from "function reference" link
+
+ -- Rafael Laboissière <rafael@debian.org>  Tue, 13 Jun 2023 17:45:46 -0300
+
+dh-octave (1.4.0) experimental; urgency=medium
+
+  * dh_octave_make.in: Add upstream BuildRequires field to Build-Depends
+
+ -- Rafael Laboissière <rafael@debian.org>  Sun, 30 Apr 2023 10:24:51 -0300
+
+dh-octave (1.3.1) experimental; urgency=medium
+
+  * dh_octave_make.in: Fix regex for finding the upstream bug database
+
+ -- Rafael Laboissière <rafael@debian.org>  Sun, 26 Mar 2023 02:59:11 -0300
+
+dh-octave (1.3.0) experimental; urgency=medium
+
+  * dh_octave_make.in:
+    + Use Homepage at gnu-octave.github.io
+    + Drop extraneuous trailing whitespace from package name
+  * Get upstream metadata from gnu-octave.github.io
+    + dh_octave_make.in: Parse upstream homepage for the package
+    + d/control: Include dependencies on needed Perl modules
+
+ -- Rafael Laboissière <rafael@debian.org>  Sat, 25 Mar 2023 15:58:58 -0300
+
+dh-octave (1.2.7) unstable; urgency=medium
+
+  * Annotate Build-Depends on shunit2 as <!nocheck> (Closes: #1029975)
+  * Update standards version to 4.6.2, no changes needed.
+
+ -- Sébastien Villemot <sebastien@debian.org>  Tue, 31 Jan 2023 15:25:13 +0100
+
+dh-octave (1.2.6) unstable; urgency=medium
+
+  * dh_octave_substvar: Remove trailing newline from octave-abi-N in
+    ${shlibs:Depends}
+
+ -- Sébastien Villemot <sebastien@debian.org>  Mon, 19 Dec 2022 16:45:03 +0100
+
+dh-octave (1.2.5) unstable; urgency=medium
+
+  * dh_octave_substvar: Remove trailing newline from package names
+    present in Depends (Closes: #1025714)
+
+ -- Rafael Laboissière <rafael@debian.org>  Thu, 08 Dec 2022 20:03:25 -0300
+
+dh-octave (1.2.4) unstable; urgency=medium
+
+  * dh_octave_make.in: Use new URL at gnu-octave.github.io for d/watch
+
+ -- Rafael Laboissière <rafael@debian.org>  Wed, 14 Sep 2022 07:58:35 -0300
+
+dh-octave (1.2.3) unstable; urgency=medium
+
+  * Use distclean target for cleaning files in upstream src directory
+    + dh_octave_clean: Ditto
+    + test_dh_octave.sh: Adjust unit test
+  * test_dh_octave.sh: Add unit test for testing the removal of src/*-tst files
+
+ -- Rafael Laboissière <rafael@debian.org>  Wed, 06 Jul 2022 04:51:08 -0300
+
+dh-octave (1.2.2) unstable; urgency=medium
+
+  * dh_octave_clean: Remove src/*-tst files
+
+ -- Rafael Laboissière <rafael@debian.org>  Tue, 05 Jul 2022 10:28:19 -0300
+
+dh-octave (1.2.1) unstable; urgency=medium
+
+  * dh_octave_make.in: Ignore case of field names in the DESCRIPTION file
+  * d/control: Build-depends on octave-dev
+    This is necessary because the command octave-config is used in
+    test_dh_octave.sh.
+
+ -- Rafael Laboissière <rafael@debian.org>  Sat, 18 Jun 2022 06:08:22 -0300
 
 dh-octave (1.2.0) unstable; urgency=medium
 

--- a/debian/control
+++ b/debian/control
@@ -6,11 +6,11 @@ Uploaders: Sébastien Villemot <sebastien@debian.org>,
 Section: devel
 Priority: optional
 Build-Depends: debhelper-compat (= 13),
-               libparse-debcontrol-perl,
                dh-exec,
-               octave,
-               shunit2
-Standards-Version: 4.6.1
+               libparse-debcontrol-perl,
+               octave-dev,
+               shunit2 <!nocheck>
+Standards-Version: 4.6.2
 Vcs-Browser: https://salsa.debian.org/pkg-octave-team/dh-octave
 Vcs-Git: https://salsa.debian.org/pkg-octave-team/dh-octave.git
 Rules-Requires-Root: no
@@ -18,14 +18,16 @@ Rules-Requires-Root: no
 Package: dh-octave
 Provides: dh-sequence-octave
 Architecture: all
-Depends: octave-dev,
+Depends: cme,
          debhelper-compat (= 13),
-         cme,
-         libconfig-model-dpkg-perl,
-         libparse-debcontrol-perl,
-         libmime-tools-perl,
-         libfile-find-rule-perl,
          dh-octave-autopkgtest,
+         libconfig-model-dpkg-perl,
+         libfile-find-rule-perl,
+         libhtml-parser-perl,
+         libmime-tools-perl,
+         libparse-debcontrol-perl,
+         libwww-perl,
+         octave-dev,
          ${misc:Depends},
          ${perl:Depends}
 Description: Debhelper-based infrastructure for building Octave add-on packages

--- a/dh_octave_check
+++ b/dh_octave_check
@@ -133,7 +133,7 @@ disp ('Checking m files ...');
 [usr_pkg, sys_pkg] = pkg ('list');
 for i = 1 : length (sys_pkg)
     name = sys_pkg {1, i}.name;
-    ## Do not load the package being checked, sinc
+    ## Do not load the package being checked, since
     ## old, incompatible version may be installed.
     if strcmp ("$package", name) != 1
         pkg ('load', name);

--- a/dh_octave_clean
+++ b/dh_octave_clean
@@ -47,23 +47,24 @@ unlink ("local-list");
 
 =pod
 
-It also cleans any F<inst/*-api-v*>, F<src/*.o> and F<src/*.oct> files
-left over from the build process.
+It also cleans any F<inst/*-api-v*>, F<src/*.o>, F<src/*.oct> and
+F<src/*-tst> files left over by the build process.
 
 =cut
 
 rmtree $_ foreach glob "inst/*-api-v*";
 unlink $_ foreach glob "src/*.o";
 unlink $_ foreach glob "src/*.oct";
+unlink $_ foreach glob "src/*-tst";
 
 =pod
 
-Finally, it runs B<make clean> in the F<src> directory, if it exists, in
-order to do further cleaning.
+Finally, it runs both B<make clean> and B<make distclean> in the
+F<src> directory, if it exists, in order to do further cleaning.
 
 =cut
 
-complex_doit ("make -k -C src clean || true");
+complex_doit ("make -k -C src clean distclean || true");
 
 =head1 SEE ALSO
 

--- a/dh_octave_make.in
+++ b/dh_octave_make.in
@@ -88,6 +88,9 @@ Rafael Laboissière E<lt>rafael@debian.orgE<gt>
 
 =cut
 
+use HTML::Parser;
+use LWP::Simple;
+
 ### Get program name
 (my $prog = $0) =~ s|.*/||;
 
@@ -129,12 +132,16 @@ sub check ($) {
 
 ### Read the fields present in the DESCRIPTION file
 open (FID, "< DESCRIPTION");
-/([^:]+): (.*)/ and $pkgdata{$1} = $2 while (<FID>);
+/([^:]+): (.*)/
+    and $field = ucfirst ($1)
+    and $pkgdata{$field} = $2
+  while (<FID>);
 close FID;
 
 ### Check for some mandatory fields
 check ("Name");
 my $name = lc $pkgdata{Name};
+$name =~ s/\s+$//; ## Drop extraneuous trailing whitespace
 check ("Version");
 my $version = $pkgdata{Version};
 check ("Title");
@@ -155,7 +162,8 @@ my $compat = #Compat#;
 ### Create the debian/watch file.
 writefile (">", "debian/watch",
            "version=4
-http://sf.net/octave/$name-(.+)\\.tar\\.gz
+https://gnu-octave.github.io/packages/$name/	\
+  https://downloads.sourceforge.net/project/octave/Octave%20Forge%20Packages/Individual%20Package%20Releases/$name-(.+).tar.gz
 ");
 
 ### Create the debian/changelog file.
@@ -199,14 +207,18 @@ if ($architecture eq "any") {
     $shlibs = ", \${shlibs:Depends}";
 }
 
+$sysbuilddep = exists $pkgdata{BuildRequires}
+               ? ", $pkgdata{BuildRequires}"
+               : "";
+
 writefile (">", "debian/control",
            "Source: octave-$name
 Section: math
 Priority: optional
 Maintainer: Debian Octave Group <team+pkg-octave-team\@tracker.debian.org>
-${uploaders}Build-Depends: debhelper-compat (= $compat), dh-octave (>= #Version#), dh-sequence-octave
+${uploaders}Build-Depends: debhelper-compat (= $compat), dh-octave (>= #Version#), dh-sequence-octave$sysbuilddep
 Standards-Version: #Standards-Version#
-Homepage: https://octave.sourceforge.io/$name/
+Homepage: https://gnu-octave.github.io/packages/$name/
 Vcs-Git: #Vcs-Git#
 Vcs-Browser: #Vcs-Browser#
 Testsuite: autopkgtest-pkg-octave
@@ -236,7 +248,8 @@ unless (-e "debian/copyright") {
     chomp $year;
 
     writefile (">>", "debian/copyright",
-	       "Files: debian/*
+	       "
+Files: debian/*
 Copyright: $year $author
 License: GPL-3+
 
@@ -265,11 +278,98 @@ License: GPL-3+
 makedir "debian/upstream";
 writefile (">", "debian/upstream/metadata",
     "Name: $title
-Contact: $maintainer
-Bug-Database: https://savannah.gnu.org/bugs/?group=octave
-Bug-Submit: https://savannah.gnu.org/bugs/?func=additem&group=octave
-Repository-Browse: https://octave.sourceforge.io/pkg-repository/$name/
-");
+Contact: $maintainer\n");
+
+### Gather upstream information from gnu-octave.github.io
+my $response = LWP::Simple::get ("https://gnu-octave.github.io/packages/$name/");
+
+my $in_li = 0;
+my $in_a = 0;
+my $href;
+my %upstream_info;
+
+sub start {
+    my ($tag, $attr) = @_;
+    if ($tag =~ /^li$/i) {
+	$in_li  = 1;
+    }
+    if ($in_li && $tag =~ /^a$/i) {
+	$in_a  = 1;
+	$href = $attr->{'href'};
+    }
+}
+
+sub end {
+    my ($tag) = @_;
+    if ($tag =~ /^li$/i) {
+	$in_li  = 0;
+    }
+    if ($tag =~ /^a$/i) {
+	$in_a  = 0;
+    }
+}
+
+sub text {
+    my ($text) = @_;
+    if ($in_a) {
+	if ($text =~ /^\s*news\s*$/) {
+            $upstream_info{news} = $href;
+        }
+	if ($text =~ /^\s*repository\s*$/) {
+            $upstream_info{repository} = $href;
+        }
+	if ($text =~ /^\s*(package documentation|function reference)\s*$/) {
+            $upstream_info{documentation} = $href;
+        }
+	if ($text =~ /^\s*report (a |)problem( or bugs|)\s*$/) {
+            $upstream_info{bug_database} = $href;
+        }
+    }
+}
+
+if (defined $response) {
+
+    my $p = HTML::Parser->new(
+        api_version     => 3,
+        start_h         => [\&start, "tagname, attr"],
+        end_h           => [\&end,   "tagname"],
+        text_h          => [\&text,   "dtext"],
+
+    );
+
+    $p->parse($response);
+
+    if (defined $upstream_info{bug_database}) {
+	my $bug_url = $upstream_info{bug_database};
+        writefile (">>", "debian/upstream/metadata",
+                   "Bug-Database: $bug_url\n");
+	if ($bug_url =~ m{^(.*github.com/.*/issues)/*$}) {
+            writefile (">>", "debian/upstream/metadata",
+                       "Bug-Submit: $1/new\n");
+	}
+    }
+    if (defined $upstream_info{news}) {
+        writefile (">>", "debian/upstream/metadata",
+                   "Changelog: $upstream_info{news}\n");
+    }
+    if (defined $upstream_info{repository}) {
+	my $repo_url = $upstream_info{repository};
+	if ($repo_url =~ m{^(.*github.com/.*[^/])/*$}) {
+            writefile (">>", "debian/upstream/metadata",
+                       "Repository: $1.git\n");
+	}
+	if ($repo_url =~ m{^(.*gitlab.com/.*[^/])/*$}) {
+            writefile (">>", "debian/upstream/metadata",
+                       "Repository: $1.git\n");
+	}
+        writefile (">>", "debian/upstream/metadata",
+                   "Repository-Browse: $repo_url\n");
+    }
+    if (defined $upstream_info{documentation}) {
+        writefile (">>", "debian/upstream/metadata",
+                   "Documentation: $upstream_info{documentation}\n");
+    }
+}
 
 ### Create the debian/gbp.conf file.
 writefile (">", "debian/gbp.conf", "[DEFAULT]

--- a/dh_octave_substvar
+++ b/dh_octave_substvar
@@ -90,6 +90,8 @@ if (-f "DESCRIPTION") {
                 $ver =~ s/(\d)/$epoch$1/;
                 $depends {"octave-$pkg"} = $ver;
             } else {
+		## Remove trailing newline, see Bug#1025714
+		chomp;
                 $depends {"octave-$_"} = "";
             }
         } grep {not /^octave/i} split (", ", $deps);
@@ -104,6 +106,7 @@ if (-f "DESCRIPTION") {
 ### Get the current ABI verson of Octave
 my $api_version = qx {/usr/bin/mkoctfile --print API_VERSION};
 $api_version =~ s/api-v//;
+chomp $api_version;
 
 foreach my $package (@{$dh{DOPACKAGES}}) {
     delsubstvar ($package, 'octave:Depends');

--- a/test_dh_octave.sh
+++ b/test_dh_octave.sh
@@ -91,8 +91,15 @@ test_dh_octave_clean_no_src_dir() {
                  "$(cat stdout stderr | grep src: | sed 's/.*src: //')"
 }
 
+test_dh_octave_clean_remove_tst() {
+    tst_file=src/test.cc-tst
+    has $tst_file ""
+    run dh_octave_clean
+    assertFalse "test -f $tst_file"
+}
+
 test_dh_octave_clean_with_src_Makefile() {
-    has src/Makefile "clean:\n	@echo done"
+    has src/Makefile "distclean:\n	@echo done"
     run dh_octave_clean
     assertEquals 0 "$exitstatus"
     assertEquals "done" "$(cat stdout stderr| grep done)"


### PR DESCRIPTION
Fix `nlopt` build error.

Ref: https://github.com/deepin-community/Repository-Integration/pull/232#issuecomment-1619764768
Ref: https://bugs.debian.org/1025714